### PR TITLE
Deprecate this repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+This project is no longer actively developed or maintained.
+
+For new work on this check out [Python Query Cursors](https://cloud.google.com/appengine/docs/python/datastore/queries#Python_Query_cursors)
+
+
 # Suggestion Box
 
 "Suggestion Box" is an example application that covers two different


### PR DESCRIPTION
The [article](https://cloud.google.com/appengine/articles/paging) this repo is associated with is deprecated. This repo is actually updated with token-based paging, but there are other examples that do that (linked in the readme) that we should double-down on.
